### PR TITLE
Replaced "md" by "Mat" 

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -4,7 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { routing } from './app.routes';
-import { MdButtonModule, MdRadioModule, MdInputModule, MdMenuModule, MdCheckboxModule } from '@angular/material';
+import { MatButtonModule, MatRadioModule, MatInputModule, MatMenuModule, MatCheckboxModule } from '@angular/material';
 
 import { AppComponent } from './app.component';
 import { SidebarComponent } from './sidebar/sidebar.component';
@@ -61,11 +61,11 @@ import { WizardComponent } from './dashboard/component/wizard/wizard.component';
     HttpModule,
     routing,
     BrowserAnimationsModule,
-    MdButtonModule,
-    MdRadioModule,
-    MdInputModule,
-    MdMenuModule,
-    MdCheckboxModule
+    MatButtonModule,
+    MatRadioModule,
+    MatInputModule,
+    MatMenuModule,
+    MatCheckboxModule
   ],
   providers: [SettingsService],
   bootstrap: [AppComponent]

--- a/src/app/shared/navbar/navbar.component.html
+++ b/src/app/shared/navbar/navbar.component.html
@@ -1,27 +1,27 @@
 <div class="nav-bar">
   <div class="left-part">
-    <button md-mini-fab id="nav-left-button"><i class="material-icons" style="font-size:18px;">more_vert</i></button>
+    <button mat-mini-fab id="nav-left-button"><i class="material-icons" style="font-size:18px;">more_vert</i></button>
     <h4>{{ title }}</h4>
   </div>
   <div class="right-part">
     <div class="right-part" id="nav-right">
-      <md-input-container color="#ff0000">
-        <input mdInput type="search" placeholder="Search">
-      </md-input-container>
-      <button md-mini-fab class="search-btn"><i class="material-icons" style="font-size:18px;">search</i></button>
-      <button md-icon-button><i class="material-icons icon-btn">dashboard</i></button>
-      <app-msgiconbtn icon="notifications" number="5" [mdMenuTriggerFor]="menu"></app-msgiconbtn>
-      <button md-icon-button><i class="material-icons icon-btn">person</i></button>
-      <md-menu #menu="mdMenu">
-        <button md-menu-item>Mike John responded to your email</button>
-        <button md-menu-item>You have 5 new tasks</button>
-        <button md-menu-item>You're now friend with Andrew</button>
-        <button md-menu-item>Another Notification</button>
-        <button md-menu-item>Another One</button>
-      </md-menu>
+      <mat-input-container color="#ff0000">
+        <input matInput type="search" placeholder="Search">
+      </mat-input-container>
+      <button mat-mini-fab class="search-btn"><i class="material-icons" style="font-size:18px;">search</i></button>
+      <button mat-icon-button><i class="material-icons icon-btn">dashboard</i></button>
+      <app-msgiconbtn icon="notifications" number="5" [matMenuTriggerFor]="menu"></app-msgiconbtn>
+      <button mat-icon-button><i class="material-icons icon-btn">person</i></button>
+      <mat-menu #menu="matMenu">
+        <button mat-menu-item>Mike John responded to your email</button>
+        <button mat-menu-item>You have 5 new tasks</button>
+        <button mat-menu-item>You're now friend with Andrew</button>
+        <button mat-menu-item>Another Notification</button>
+        <button mat-menu-item>Another One</button>
+      </mat-menu>
     </div>
     <div id="menu">
-      <button md-icon-button (click)="menuClick()"><i class="material-icons">menu</i></button>
+      <button mat-icon-button (click)="menuClick()"><i class="material-icons">menu</i></button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
I saw you had created a great dashboard based on Angular Material. 

Thus, I fork your repo to see more details and run on my local host. Then I realized there are a 'Md' issue since the SCSS already requires to use mat instead of md and I just replaced all by using regex "md([A-Z])(\w+)" in find and replace "mat$1$2" for a quick find and replace.

This worked in VS Code!!

Thanks for providing such great dashboard simple! Hope you could keep doing this awesome job.